### PR TITLE
LocalDriver now uses double fork and deamonizes child processes

### DIFF
--- a/src/kong/drivers/local_driver.py
+++ b/src/kong/drivers/local_driver.py
@@ -208,7 +208,7 @@ class LocalDriver(DriverBase):
                 job.save()
 
         except psutil.NoSuchProcess:
-            logger.debug("Job %s with pid %d doesn't exist, chck exit code", job, pid)
+            logger.debug("Job %s with pid %d doesn't exist, check exit code", job, pid)
             check_exit_code()
             if save:
                 job.save()

--- a/src/kong/drivers/local_driver.py
+++ b/src/kong/drivers/local_driver.py
@@ -1,6 +1,5 @@
 import datetime
 import multiprocessing
-import sys
 import tempfile
 import os
 from contextlib import contextmanager
@@ -314,7 +313,6 @@ class LocalDriver(DriverBase):
         if save:
             job.save()
 
-
         logger.debug("Submitted job as %s", job)
 
     @checked_job  # type: ignore
@@ -355,7 +353,7 @@ class LocalDriver(DriverBase):
                 proc.wait(timeout=timeout)
             except psutil.TimeoutExpired as e:
                 raise TimeoutError(str(e))
-        except psutil.NoSuchProcess as e:
+        except psutil.NoSuchProcess:
             logger.debug("Wait encountered non-existing pid, we're done")
 
         return cast(Job, self.sync_status(job))

--- a/src/kong/drivers/local_driver.py
+++ b/src/kong/drivers/local_driver.py
@@ -305,6 +305,7 @@ class LocalDriver(DriverBase):
         p = multiprocessing.Process(target=LocalDriver.spawn_child, args=(cmd, pid))
         p.start()
         p.join()
+        logger.debug("Double fork child: terminating")
         assert pid.value != 0, "Got invalid pid 0"
         logger.debug("Got pid: %d", pid.value)
         job.data["pid"] = pid.value
@@ -313,7 +314,6 @@ class LocalDriver(DriverBase):
         if save:
             job.save()
 
-        logger.debug("Double fork child: terminating")
 
         logger.debug("Submitted job as %s", job)
 

--- a/src/kong/drivers/local_driver.py
+++ b/src/kong/drivers/local_driver.py
@@ -1,4 +1,6 @@
 import datetime
+import multiprocessing
+import sys
 import tempfile
 import os
 from contextlib import contextmanager
@@ -190,7 +192,7 @@ class LocalDriver(DriverBase):
             proc = psutil.Process(pid)
             if proc.is_running():
                 # is running, but is it zombie waiting to be reaped?
-                if proc.status() == psutil.STATUS_ZOMBIE:
+                if proc.status() == psutil.STATUS_ZOMBIE:  # pragma: no cover
                     logger.debug(
                         "Job %s with pid %s is running but zombie, reaping", job, pid
                     )
@@ -206,7 +208,7 @@ class LocalDriver(DriverBase):
                 job.save()
 
         except psutil.NoSuchProcess:
-            logger.debug("Job %s with pid %d doesn't exist, check exit code", job, pid)
+            logger.debug("Job %s with pid %d doesn't exist, chck exit code", job, pid)
             check_exit_code()
             if save:
                 job.save()
@@ -280,6 +282,14 @@ class LocalDriver(DriverBase):
                 batch_size=self.batch_size,
             )
 
+    @classmethod
+    def spawn_child(
+        cls, cmd: List[str], pid: multiprocessing.Value
+    ) -> None:  # pragma: no cover
+        os.setsid()  # deamonize so we detach from handlers, avoid zombie state
+        proc = Popen(cmd, stdin=None, stdout=None, stderr=None, close_fds=True)
+        pid.value = proc.pid
+
     @checked_job
     def submit(self, job: Job, save: bool = True) -> None:
         self.sync_status(job)
@@ -289,12 +299,22 @@ class LocalDriver(DriverBase):
         cmd = ["/usr/bin/env", "bash", job.data["jobscript"]]
         logger.debug("About to submit job with command: %s", str(cmd))
 
-        proc = Popen(cmd, stdin=None, stdout=None, stderr=None, close_fds=True)
+        pid = multiprocessing.Value("i", 0)
 
-        job.data["pid"] = proc.pid
+        logger.debug("Double fork child: spawning process")
+        p = multiprocessing.Process(target=LocalDriver.spawn_child, args=(cmd, pid))
+        p.start()
+        p.join()
+        assert pid.value != 0, "Got invalid pid 0"
+        logger.debug("Got pid: %d", pid.value)
+        job.data["pid"] = pid.value
         job.status = Job.Status.SUBMITTED
+
         if save:
             job.save()
+
+        logger.debug("Double fork child: terminating")
+
         logger.debug("Submitted job as %s", job)
 
     @checked_job  # type: ignore
@@ -329,11 +349,15 @@ class LocalDriver(DriverBase):
             )
             return job
 
-        proc = psutil.Process(pid=job.data["pid"])
         try:
-            proc.wait(timeout=timeout)
-        except psutil.TimeoutExpired as e:
-            raise TimeoutError(str(e))
+            proc = psutil.Process(pid=job.data["pid"])
+            try:
+                proc.wait(timeout=timeout)
+            except psutil.TimeoutExpired as e:
+                raise TimeoutError(str(e))
+        except psutil.NoSuchProcess as e:
+            logger.debug("Wait encountered non-existing pid, we're done")
+
         return cast(Job, self.sync_status(job))
 
     def wait_gen(

--- a/tests/test_local_driver.py
+++ b/tests/test_local_driver.py
@@ -385,13 +385,13 @@ def test_run_job_already_completed(driver, state):
 @skip_lxplus
 def test_run_job_timeout(driver, state):
     root = Folder.get_root()
-    j1 = driver.create_job(command="sleep 0.3", folder=root)
+    j1 = driver.create_job(command="sleep 1", folder=root)
     j1.submit()
 
     with pytest.raises(TimeoutError):
         driver.wait(j1, timeout=0.1)
     assert j1.status == Job.Status.RUNNING
-    time.sleep(0.3)
+    time.sleep(1)
     driver.wait(j1, timeout=0.1)
     assert j1.status == Job.Status.COMPLETED
 


### PR DESCRIPTION
this avoids signals being passed to child if kong doesn't exit immediately,
and should also avoid the zombie state.