### PR TITLE
Accumulated development

### DIFF
--- a/src/kong/drivers/local_driver.py
+++ b/src/kong/drivers/local_driver.py
@@ -2,6 +2,7 @@ import datetime
 import multiprocessing
 import tempfile
 import os
+import time
 from contextlib import contextmanager
 from subprocess import Popen
 from typing import (
@@ -408,6 +409,12 @@ class LocalDriver(DriverBase):
                 delta,
                 len(remaining_jobs),
             )
+
+            if timeout is not None:
+                if (datetime.datetime.now() - start).total_seconds() >= timeout:
+                    raise TimeoutError()
+
+            print("waiting", poll_interval)
             time.sleep(poll_interval)
 
     @checked_job

--- a/src/kong/drivers/local_driver.py
+++ b/src/kong/drivers/local_driver.py
@@ -15,7 +15,6 @@ from typing import (
     Dict,
     Collection,
     Iterator,
-    cast,
     Sequence,
 )
 import uuid
@@ -375,7 +374,7 @@ class LocalDriver(DriverBase):
                 j
                 for j in jobs
                 if j.status
-                   not in (Job.Status.COMPLETED, Job.Status.FAILED, Job.Status.UNKNOWN)
+                not in (Job.Status.COMPLETED, Job.Status.FAILED, Job.Status.UNKNOWN)
             ]
             if len(remaining_jobs) == 0:
                 logger.debug("Waiting completed")

--- a/src/kong/drivers/slurm_driver.py
+++ b/src/kong/drivers/slurm_driver.py
@@ -3,7 +3,18 @@ import os
 import re
 from abc import ABC, abstractmethod
 from datetime import date, timedelta
-from typing import Iterator, Iterable, Optional, Union, List, Sequence, cast, Collection, Dict, Any
+from typing import (
+    Iterator,
+    Iterable,
+    Optional,
+    Union,
+    List,
+    Sequence,
+    cast,
+    Collection,
+    Dict,
+    Any,
+)
 
 import sh
 from jinja2 import Environment, DictLoader
@@ -25,7 +36,9 @@ class SlurmAccountingItem:
     exit_code: int
     other: Dict[str, Any]
 
-    def __init__(self, job_id: int, status: Job.Status, exit_code: int, other: Dict[str, Any]):
+    def __init__(
+        self, job_id: int, status: Job.Status, exit_code: int, other: Dict[str, Any]
+    ):
         self.job_id = job_id
         self.status = status
         self.exit_code = exit_code
@@ -108,7 +121,11 @@ class ShellSlurmInterface(SlurmInterface):
         ]
 
         args = dict(
-            format=",".join(fields), noheader=True, parsable2=True, starttime=starttime, _iter=True
+            format=",".join(fields),
+            noheader=True,
+            parsable2=True,
+            starttime=starttime,
+            _iter=True,
         )
 
         if len(jobs) > 0 and len(jobs) < 20:
@@ -132,12 +149,17 @@ class ShellSlurmInterface(SlurmInterface):
             # job_id, status, exit = line.split("|", 3)
             if not job_id.isdigit():
                 continue
-            yield SlurmAccountingItem.from_parts(job_id, status, exit, other=dict(
-                node=data["NodeList"] if data["NodeList"] != "" else None,
-                submit=data["Submit"] if data["Submit"] != "" else None,
-                start=data["Start"] if data["Start"] != "" else None,
-                end=data["End"] if data["End"] != "" else None,
-            ))
+            yield SlurmAccountingItem.from_parts(
+                job_id,
+                status,
+                exit,
+                other=dict(
+                    node=data["NodeList"] if data["NodeList"] != "" else None,
+                    submit=data["Submit"] if data["Submit"] != "" else None,
+                    start=data["Start"] if data["Start"] != "" else None,
+                    end=data["End"] if data["End"] != "" else None,
+                ),
+            )
 
     def sbatch(self, job: Job) -> int:
         assert self._sbatch is not None

--- a/src/kong/drivers/slurm_driver.py
+++ b/src/kong/drivers/slurm_driver.py
@@ -133,7 +133,10 @@ class ShellSlurmInterface(SlurmInterface):
             if not job_id.isdigit():
                 continue
             yield SlurmAccountingItem.from_parts(job_id, status, exit, other=dict(
-                node=data["NodeList"],
+                node=data["NodeList"] if data["NodeList"] != "" else None,
+                submit=data["Submit"] if data["Submit"] != "" else None,
+                start=data["Start"] if data["Start"] != "" else None,
+                end=data["End"] if data["End"] != "" else None,
             ))
 
     def sbatch(self, job: Job) -> int:

--- a/src/kong/model/job.py
+++ b/src/kong/model/job.py
@@ -288,7 +288,7 @@ class Job(BaseModel):
 
 
 color_dict = {
-    Job.Status.UNKNOWN: "red",
+    Job.Status.UNKNOWN: "magenta",
     Job.Status.CREATED: "white",
     Job.Status.SUBMITTED: "yellow",
     Job.Status.RUNNING: "blue",

--- a/src/kong/model/job.py
+++ b/src/kong/model/job.py
@@ -219,7 +219,9 @@ class Job(BaseModel):
         driver.resubmit(self)
 
     @with_driver
-    def wait(self, driver: DriverBase, timeout: Optional[int] = None, **kwargs: Any) -> None:
+    def wait(
+        self, driver: DriverBase, timeout: Optional[int] = None, **kwargs: Any
+    ) -> None:
         """
         wait(timeout: Optional[int] = None)
 

--- a/src/kong/model/job.py
+++ b/src/kong/model/job.py
@@ -219,7 +219,7 @@ class Job(BaseModel):
         driver.resubmit(self)
 
     @with_driver
-    def wait(self, driver: DriverBase, timeout: Optional[int] = None) -> None:
+    def wait(self, driver: DriverBase, timeout: Optional[int] = None, **kwargs: Any) -> None:
         """
         wait(timeout: Optional[int] = None)
 
@@ -227,7 +227,7 @@ class Job(BaseModel):
 
         :param timeout: If set to a number, will raise a `TimeoutError` after that time
         """
-        driver.wait(self, timeout=timeout)
+        driver.wait(self, timeout=timeout, **kwargs)
 
     @with_driver
     def kill(self, driver: DriverBase) -> None:

--- a/src/kong/repl.py
+++ b/src/kong/repl.py
@@ -614,7 +614,7 @@ class Repl(cmd.Cmd):
         click.echo_via_pager(reader())
 
     @parse_arguments
-    @click.argument("path")
+    @click.argument("path", nargs=-1)
     @click.option(
         "--notify/--no-notify",
         default=True,
@@ -637,7 +637,7 @@ class Repl(cmd.Cmd):
     )
     def do_wait(
         self,
-        path: str,
+        path: List[str],
         notify: bool,
         recursive: bool,
         poll_interval: Optional[int],

--- a/src/kong/repl.py
+++ b/src/kong/repl.py
@@ -368,7 +368,7 @@ class Repl(cmd.Cmd):
             else:
                 names.append(item.name)
 
-        click.secho(f"Moved {', '.join(names)} -> {dest}")
+        click.secho(f"Moved -> {dest}")
 
     @parse_arguments
     @click.argument("path")

--- a/src/kong/state.py
+++ b/src/kong/state.py
@@ -702,7 +702,7 @@ class State:
 
     def wait(
         self,
-        jobspec: JobSpec,
+        jobspecs: List[JobSpec],
         recursive: bool = False,
         notify: bool = True,
         timeout: Optional[int] = None,
@@ -723,7 +723,7 @@ class State:
         :return: An iterable if `progress` is `True`, else `None`.
         """
         it = self._wait_gen(
-            jobspec=jobspec,
+            jobspecs=jobspecs,
             recursive=recursive,
             notify=notify,
             timeout=timeout,
@@ -738,15 +738,16 @@ class State:
 
     def _wait_gen(
         self,
-        jobspec: JobSpec,
+        jobspecs: List[JobSpec],
         recursive: bool = False,
         notify: bool = True,
         timeout: Optional[int] = None,
         poll_interval: Optional[int] = None,
         update_interval: Optional[timedelta] = None,
     ) -> Iterable[List[Job]]:
-        jobs: List[Job]
-        jobs = list(self._extract_jobs(jobspec, recursive=recursive))
+        jobs: List[Job] = []
+        for jobspec in jobspecs:
+            jobs.extend(self._extract_jobs(jobspec, recursive=recursive))
 
         logger.debug("Jobs for waiting: %s", jobs)
         assert len(jobs) > 0

--- a/src/kong/state.py
+++ b/src/kong/state.py
@@ -437,7 +437,8 @@ class State:
                     first_job.ensure_driver_instance(self.config)
                     driver = first_job.driver_instance
 
-                    driver.bulk_remove(jobs)
+                    with Spinner(f"Removing {len(jobs)} jobs"):
+                        driver.bulk_remove(jobs)
 
                 for folder in folders:
                     folder.delete_instance(recursive=True, delete_nullable=True)

--- a/src/kong/state.py
+++ b/src/kong/state.py
@@ -703,7 +703,7 @@ class State:
 
     def wait(
         self,
-        jobspecs: List[JobSpec],
+        jobspecs: Sequence[JobSpec],
         recursive: bool = False,
         notify: bool = True,
         timeout: Optional[int] = None,
@@ -739,7 +739,7 @@ class State:
 
     def _wait_gen(
         self,
-        jobspecs: List[JobSpec],
+        jobspecs: Sequence[JobSpec],
         recursive: bool = False,
         notify: bool = True,
         timeout: Optional[int] = None,

--- a/tests/test_local_driver.py
+++ b/tests/test_local_driver.py
@@ -426,6 +426,16 @@ def test_run_killed(driver, state):
     j1.wait()
     assert j1.status == Job.Status.UNKNOWN
 
+def test_wait(driver, state):
+    j1 = state.create_job(command="sleep 2")
+
+    with pytest.raises(ValueError):
+        driver.wait(j1)
+
+    j1.submit()
+
+    with pytest.raises(TimeoutError):
+        driver.wait(j1, poll_interval=0.05, timeout=0.2)
 
 @skip_lxplus
 def test_run_terminated(driver, state):

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -580,14 +580,14 @@ def test_wait(repl, state, monkeypatch):
 
     repl.onecmd("wait * --no-notify --recursive --poll-interval 50")
     wait.assert_called_once_with(
-        "*", notify=False, recursive=True, poll_interval=50, update_interval=None
+        ("*",), notify=False, recursive=True, poll_interval=50, update_interval=None
     )
 
     wait.reset_mock()
 
     repl.onecmd("wait * --notify --recursive --poll-interval 50 --notify-interval 30m")
     wait.assert_called_once_with(
-        "*",
+        ("*",),
         notify=True,
         recursive=True,
         poll_interval=50,

--- a/tests/test_slurm_driver.py
+++ b/tests/test_slurm_driver.py
@@ -39,32 +39,32 @@ def driver(monkeypatch, state):
 
 def test_sacct_parse(driver, monkeypatch, state):
     sacct_output = """
-5205197|FAILED|2:0
-5205197.batch|FAILED|2:0
-5205197.extern|COMPLETED|0:0
-5205197.0|FAILED|2:0
-5205206|FAILED|2:0
-5205206.batch|FAILED|2:0
-5205206.extern|COMPLETED|0:0
-5205206.0|FAILED|2:0
-5205209|FAILED|2:0
-5205209.batch|FAILED|2:0
-5205209.extern|COMPLETED|0:0
-5205209.0|FAILED|2:0
-5205223|FAILED|13:0
-5205223.batch|FAILED|13:0
-5205223.extern|COMPLETED|0:0
-5205223.0|FAILED|13:0
-5205350|FAILED|13:0
-5205350.batch|FAILED|13:0
-5205350.extern|COMPLETED|0:0
-5205350.0|FAILED|13:0
-5205355|PENDING|0:0
-5205757|COMPLETED|0:0
-5205757.batch|COMPLETED|0:0
-5205757.extern|COMPLETED|0:0
-5205757.0|COMPLETED|0:0
-22822|NOCLUE|0:0
+5205197|FAILED|2:0|2020-03-17T10:10:35|2020-03-17T10:16:23|2020-03-17T14:16:48|z0021
+5205197.batch|FAILED|2:0|2020-03-17T10:10:35|2020-03-17T10:16:23|2020-03-17T14:16:48|z0021
+5205197.extern|COMPLETED|0:0|2020-03-17T10:10:35|2020-03-17T10:16:23|2020-03-17T14:16:48|z0021
+5205197.0|FAILED|2:0|2020-03-17T10:10:35|2020-03-17T10:16:23|2020-03-17T14:16:48|z0021
+5205206|FAILED|2:0|2020-03-18T10:10:35|2020-03-18T10:16:23|2020-03-18T14:16:48|z0022
+5205206.batch|FAILED|2:0|2020-03-18T10:10:35|2020-03-18T10:16:23|2020-03-18T14:16:48|z0022
+5205206.extern|COMPLETED|0:0|2020-03-18T10:10:35|2020-03-18T10:16:23|2020-03-18T14:16:48|z0022
+5205206.0|FAILED|2:0|2020-03-18T10:10:35|2020-03-18T10:16:23|2020-03-18T14:16:48|z0022
+5205209|FAILED|2:0|2020-03-19T10:10:35|2020-03-19T10:16:23|2020-03-19T14:16:48|z0023
+5205209.batch|FAILED|2:0|2020-03-19T10:10:35|2020-03-19T10:16:23|2020-03-19T14:16:48|z0023
+5205209.extern|COMPLETED|0:0|2020-03-19T10:10:35|2020-03-19T10:16:23|2020-03-19T14:16:48|z0023
+5205209.0|FAILED|2:0|2020-03-19T10:10:35|2020-03-19T10:16:23|2020-03-19T14:16:48|z0023
+5205223|FAILED|13:0|2020-03-20T10:10:35|2020-03-20T10:16:23|2020-03-20T14:16:48|z0024
+5205223.batch|FAILED|13:0|2020-03-20T10:10:35|2020-03-20T10:16:23|2020-03-20T14:16:48|z0024
+5205223.extern|COMPLETED|0:0|2020-03-20T10:10:35|2020-03-20T10:16:23|2020-03-20T14:16:48|z0024
+5205223.0|FAILED|13:0|2020-03-20T10:10:35|2020-03-20T10:16:23|2020-03-20T14:16:48|z0024
+5205350|FAILED|13:0|2020-03-21T10:10:35|2020-03-21T10:16:23|2020-03-21T14:16:48|z0025
+5205350.batch|FAILED|13:0|2020-03-21T10:10:35|2020-03-21T10:16:23|2020-03-21T14:16:48|z0025
+5205350.extern|COMPLETED|0:0|2020-03-21T10:10:35|2020-03-21T10:16:23|2020-03-21T14:16:48|z0025
+5205350.0|FAILED|13:0|2020-03-21T10:10:35|2020-03-21T10:16:23|2020-03-21T14:16:48|z0025
+5205355|PENDING|0:0|2020-03-22T10:10:35|||
+5205757|COMPLETED|0:0|2020-03-23T10:10:35|2020-03-23T10:16:23|2020-03-23T14:16:48|z0026
+5205757.batch|COMPLETED|0:0|2020-03-23T10:10:35|2020-03-23T10:16:23|2020-03-23T14:16:48|z0026
+5205757.extern|COMPLETED|0:0|2020-03-23T10:10:35|2020-03-23T10:16:23|2020-03-23T14:16:48|z0026
+5205757.0|COMPLETED|0:0|2020-03-23T10:10:35|2020-03-23T10:16:23|2020-03-23T14:16:48|z0026
+22822|NOCLUE|0:0||2020-03-17T10:10:35||
     """.strip()
 
     with monkeypatch.context() as m:
@@ -78,23 +78,31 @@ def test_sacct_parse(driver, monkeypatch, state):
         starttime = date.today() - td
 
         mock.assert_called_once_with(
-            brief=True, noheader=True, parsable2=True, starttime=starttime, _iter=True
+            format="JobID,State,ExitCode,Submit,Start,End,NodeList", noheader=True, parsable2=True, starttime=starttime, _iter=True
         )
 
+        db = datetime(2020, 3, 17, 10, 10, 35)
+        def fmt(dt):
+            return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+        def make_other(d, host):
+            return dict(submit=fmt(d), start=fmt(d.replace(minute=16, second=23)), end=fmt(d.replace(hour=14, minute=16, second=48)), node=host)
+
         ref = [
-            SlurmAccountingItem(5_205_197, Job.Status.FAILED, 2),
-            SlurmAccountingItem(5_205_206, Job.Status.FAILED, 2),
-            SlurmAccountingItem(5_205_209, Job.Status.FAILED, 2),
-            SlurmAccountingItem(5_205_223, Job.Status.FAILED, 13),
-            SlurmAccountingItem(5_205_350, Job.Status.FAILED, 13),
-            SlurmAccountingItem(5_205_355, Job.Status.SUBMITTED, 0),
-            SlurmAccountingItem(5_205_757, Job.Status.COMPLETED, 0),
-            SlurmAccountingItem(22822, Job.Status.UNKNOWN, 0),
+            SlurmAccountingItem(5_205_197, Job.Status.FAILED, 2, other=make_other(db, "z0021")),
+            SlurmAccountingItem(5_205_206, Job.Status.FAILED, 2, other=make_other(db.replace(day=18), "z0022")),
+            SlurmAccountingItem(5_205_209, Job.Status.FAILED, 2, other=make_other(db.replace(day=19), "z0023")),
+            SlurmAccountingItem(5_205_223, Job.Status.FAILED, 13, other=make_other(db.replace(day=20), "z0024")),
+            SlurmAccountingItem(5_205_350, Job.Status.FAILED, 13, other=make_other(db.replace(day=21), "z0025")),
+            SlurmAccountingItem(5_205_355, Job.Status.SUBMITTED, 0, other={"submit": fmt(db.replace(day=22)), "start": None, "end": None, "node": None}),
+            SlurmAccountingItem(5_205_757, Job.Status.COMPLETED, 0, other=make_other(db.replace(day=23), "z0026")),
+            SlurmAccountingItem(22822, Job.Status.UNKNOWN, 0, other={"submit": None, "start": fmt(db.replace(day=17)), "end": None, "node": None}),
         ]
 
         assert len(ref) == len(res)
         for a, b in zip(ref, res):
             assert a == b
+            assert a.other == b.other
 
         batch_job_id = 5_207_375
         sbatch = Mock(return_value=f"Submitted batch job {batch_job_id}")
@@ -117,7 +125,7 @@ def test_sacct_parse(driver, monkeypatch, state):
 
 
 def test_repr():
-    sai = SlurmAccountingItem(1, Job.Status.UNKNOWN, 0)
+    sai = SlurmAccountingItem(1, Job.Status.UNKNOWN, 0, {})
     assert repr(sai) != ""
 
 
@@ -232,7 +240,7 @@ def test_resubmit_job(driver, state, monkeypatch):
     monkeypatch.setattr(
         driver.slurm,
         "sacct",
-        Mock(return_value=[SAI(j1.batch_job_id, Job.Status.FAILED, 0)]),
+        Mock(return_value=[SAI(j1.batch_job_id, Job.Status.FAILED, 0, {})]),
     )
 
     bjid2 = 42
@@ -258,7 +266,7 @@ def test_resubmit_job(driver, state, monkeypatch):
     monkeypatch.setattr(
         driver.slurm,
         "sacct",
-        Mock(return_value=[SAI(j1.batch_job_id, Job.Status.FAILED, 0)]),
+        Mock(return_value=[SAI(j1.batch_job_id, Job.Status.FAILED, 0, {})]),
     )
 
     # will go to failed
@@ -429,8 +437,8 @@ def test_sync_status(driver, monkeypatch):
     assert j1.batch_job_id == str(batch_job_id)
 
     sacct_return = [
-        [SlurmAccountingItem(batch_job_id, Job.Status.RUNNING, 0)],
-        [SlurmAccountingItem(batch_job_id, Job.Status.FAILED, 0)],
+        [SlurmAccountingItem(batch_job_id, Job.Status.RUNNING, 0, {})],
+        [SlurmAccountingItem(batch_job_id, Job.Status.FAILED, 0, {})],
     ]
     sacct = Mock(side_effect=sacct_return)
     monkeypatch.setattr(driver.slurm, "sacct", sacct)
@@ -493,7 +501,7 @@ def test_bulk_sync_status(driver, state, monkeypatch):
     monkeypatch.setattr(driver.slurm, "sbatch", sbatch)
     driver.bulk_submit(jobs)
 
-    sacct_return = ["|".join([str(i + 1), "RUNNING", "0:0"]) for i in range(len(jobs))]
+    sacct_return = ["|".join([str(i + 1), "RUNNING", "0:0", "", "", "", ""]) for i in range(len(jobs))]
     sacct = Mock(return_value=sacct_return)
     # pretend they're all running now
     monkeypatch.setattr(driver.slurm, "_sacct", sacct)
@@ -502,7 +510,7 @@ def test_bulk_sync_status(driver, state, monkeypatch):
 
     sacct.assert_called_once_with(
         jobs=",".join([j.batch_job_id for j in jobs]),
-        brief=True,
+        format="JobID,State,ExitCode,Submit,Start,End,NodeList",
         noheader=True,
         parsable2=True,
         starttime=ANY,
@@ -513,7 +521,7 @@ def test_bulk_sync_status(driver, state, monkeypatch):
         assert job.status == Job.Status.RUNNING
 
     sacct_return = [
-        "|".join([str(i + 1), "COMPLETED" if i < 6 else "FAILED", "0:0"])
+        "|".join([str(i + 1), "COMPLETED" if i < 6 else "FAILED", "0:0"] + [""]*4)
         for i in range(len(jobs))
     ]
 
@@ -523,7 +531,7 @@ def test_bulk_sync_status(driver, state, monkeypatch):
     jobs = driver.bulk_sync_status(jobs)
     sacct.assert_called_once_with(
         jobs=",".join([j.batch_job_id for j in jobs]),
-        brief=True,
+        format="JobID,State,ExitCode,Submit,Start,End,NodeList",
         noheader=True,
         parsable2=True,
         starttime=ANY,
@@ -549,8 +557,8 @@ def test_bulk_sync_status_invalid_id(driver, state, monkeypatch):
     driver.bulk_submit(jobs)
 
     SAI = SlurmAccountingItem
-    sacct_return = [SAI(i + 1, Job.Status.RUNNING, 0) for i in range(len(jobs))]
-    sacct_return += [SAI(12_345_665, Job.Status.UNKNOWN, 0)]
+    sacct_return = [SAI(i + 1, Job.Status.RUNNING, 0, {}) for i in range(len(jobs))]
+    sacct_return += [SAI(12_345_665, Job.Status.UNKNOWN, 0, {})]
     sacct = Mock(return_value=sacct_return)
     # pretend they're all running now
     monkeypatch.setattr(driver.slurm, "sacct", sacct)
@@ -631,15 +639,15 @@ def test_wait(driver, state, monkeypatch):
         ) -> Iterator[SlurmAccountingItem]:
             values = [
                 [
-                    SlurmAccountingItem(j.batch_job_id, Job.Status.RUNNING, 0)
+                    SlurmAccountingItem(j.batch_job_id, Job.Status.RUNNING, 0, {})
                     for j in self.jobs
                 ],
                 [  # first half done
-                    SlurmAccountingItem(j.batch_job_id, Job.Status.COMPLETED, 0)
+                    SlurmAccountingItem(j.batch_job_id, Job.Status.COMPLETED, 0, {})
                     for j in self.jobs[len(self.jobs) // 2 :]
                 ],
                 [  # all done
-                    SlurmAccountingItem(j.batch_job_id, Job.Status.COMPLETED, 0)
+                    SlurmAccountingItem(j.batch_job_id, Job.Status.COMPLETED, 0, {})
                     for j in self.jobs
                 ],
             ]


### PR DESCRIPTION
- Change job color
- Local driver now uses polling (like slurm and condor) instead of waiting one by one
- Slurm stores node, submit, start and end times
- Spinner while removing
- Change in printout for `mv`