### PR TITLE
feat(job): Jobs are saved as utc and shown as local

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -692,7 +692,7 @@ python-versions = "*"
 version = "1.1.8"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
@@ -1051,7 +1051,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 ipython = ["ipython"]
 
 [metadata]
-content-hash = "04f92b46b7ac3227e3f41630bff8cee03164ea76df668e2e54a851f66c2da4f3"
+content-hash = "8b6b5155c191b7595667cd22c2a9a5e1e894b8f53b3e38ab44b8fb81dbd91054"
 python-versions = "^3.6"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ notifiers = "^1.2.1"
 jinja2 = "^2.11.2"
 pytimeparse = "^1.1.8"
 ipython = {version = "^7.16.1", optional = true}
+pytz = "^2020.1"
 
 [tool.poetry.scripts]
 kong = 'kong.cli:main'

--- a/src/kong/drivers/batch_driver_base.py
+++ b/src/kong/drivers/batch_driver_base.py
@@ -34,7 +34,7 @@ class BatchDriverBase(DriverBase):
         return self.bulk_sync_status([job])[0]
 
     def bulk_kill(self, jobs: Sequence["Job"]) -> Sequence["Job"]:
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         jobs = self.bulk_sync_status(jobs)
 
         def delete() -> Iterable["Job"]:
@@ -104,7 +104,7 @@ class BatchDriverBase(DriverBase):
             time.sleep(poll_interval)
 
     def bulk_submit(self, jobs: Iterable["Job"]) -> None:
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
 
         def sub() -> Iterable[Job]:
             for job in jobs:
@@ -214,7 +214,7 @@ class BatchDriverBase(DriverBase):
         with database.atomic():
 
             with database.atomic():
-                now = datetime.datetime.now()
+                now = datetime.datetime.utcnow()
 
                 def jobit() -> Iterable[Job]:
                     for job in jobs:

--- a/src/kong/drivers/htcondor_driver.py
+++ b/src/kong/drivers/htcondor_driver.py
@@ -342,7 +342,7 @@ class HTCondorDriver(BatchDriverBase):
         for job in jobs:
             self._check_driver(job)
 
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
 
         def proc() -> Iterable[Job]:
             job_not_found = 0

--- a/src/kong/drivers/local_driver.py
+++ b/src/kong/drivers/local_driver.py
@@ -230,7 +230,7 @@ class LocalDriver(DriverBase):
 
     def bulk_sync_status(self, jobs: Sequence[Job]) -> Sequence[Job]:
         # simply implemented as loop over single sync status for local driver
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
 
         def sync() -> Iterable[Job]:
             for job in jobs:
@@ -265,7 +265,7 @@ class LocalDriver(DriverBase):
             job.save()
 
     def bulk_kill(self, jobs: Sequence["Job"]) -> Sequence[Job]:
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
 
         def k() -> Iterable[Job]:
             for job in jobs:
@@ -281,7 +281,7 @@ class LocalDriver(DriverBase):
         return jobs
 
     def bulk_submit(self, jobs: Iterable["Job"]) -> None:
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
 
         def sub() -> Iterable[Job]:
             for job in jobs:

--- a/src/kong/drivers/slurm_driver.py
+++ b/src/kong/drivers/slurm_driver.py
@@ -334,7 +334,7 @@ class SlurmDriver(BatchDriverBase):
         for job in jobs:
             self._check_driver(job)
 
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
 
         def proc() -> Iterable[Job]:
             job_not_found = 0

--- a/src/kong/model/job.py
+++ b/src/kong/model/job.py
@@ -133,7 +133,7 @@ class Job(BaseModel):
         memory = pw.IntegerField(null=False, default=1000)  # memory in Megabytes
         status = EnumField(choices=Status, null=False, default=Status.CREATED)
 
-        created_at = pw.DateTimeField(default=datetime.datetime.now)
+        created_at = pw.DateTimeField(default=datetime.datetime.utcnow)
         updated_at = pw.DateTimeField()
 
     _driver_instance: Optional[DriverBase] = None

--- a/src/kong/repl.py
+++ b/src/kong/repl.py
@@ -262,7 +262,11 @@ class Repl(cmd.Cmd):
                     headers += ["batch job id", "created", "updated", "status"]
                     align += ["r+", "l", "l", "l"]
 
-                    dfcnv = lambda dt: dt.replace(tzinfo=pytz.utc).astimezone(dateutil.tz.tzlocal())
+                    def dfcnv(dt: datetime.datetime) -> datetime.datetime:
+                        return dt.replace(tzinfo=pytz.utc).astimezone(
+                            dateutil.tz.tzlocal()
+                        )
+
                     tfmt = "%H:%M:%S"
                     dtfmt = f"%Y-%m-%d {tfmt}"
 

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -202,7 +202,6 @@ def test_folders_recursive(db, state, monkeypatch):
         assert set(folders) == set([f1, f2, f3, f4])
 
 
-
 def test_jobs_recursive(db, state, monkeypatch):
     root = Folder.get_root()
     f1 = root.add_folder("f1")


### PR DESCRIPTION
Peewee+SQLite apparently only supports naive (no tz) datetime objects.
We save UTC always, and convert to local TZ only when showing.
