### PR TITLE
fix(drivers): Do not use transaction for bulk_submit, kill

### DIFF
--- a/src/kong/drivers/batch_driver_base.py
+++ b/src/kong/drivers/batch_driver_base.py
@@ -106,19 +106,11 @@ class BatchDriverBase(DriverBase):
     def bulk_submit(self, jobs: Iterable["Job"]) -> None:
         now = datetime.datetime.utcnow()
 
-        def sub() -> Iterable[Job]:
-            for job in jobs:
-                assert job.driver == self.__class__, "Not valid for different driver"
-                self.submit(job, save=False)
-                job.updated_at = now
-                yield job
-
-        with database.atomic():
-            Job.bulk_update(
-                sub(),
-                fields=[Job.batch_job_id, Job.status, Job.updated_at],
-                batch_size=self.batch_size,
-            )
+        for job in jobs:
+            assert job.driver == self.__class__, "Not valid for different driver"
+            self.submit(job, save=False)
+            job.updated_at = now
+            job.save()
 
     @checked_job  # type: ignore
     @contextmanager  # type: ignore

--- a/src/kong/drivers/batch_driver_base.py
+++ b/src/kong/drivers/batch_driver_base.py
@@ -37,18 +37,10 @@ class BatchDriverBase(DriverBase):
         now = datetime.datetime.utcnow()
         jobs = self.bulk_sync_status(jobs)
 
-        def delete() -> Iterable["Job"]:
-            for job in jobs:
-                self.kill(job, save=False)
-                job.updated_at = now
-                yield job
-
-        with database.atomic():
-            Job.bulk_update(
-                delete(),
-                fields=[Job.status, Job.updated_at],
-                batch_size=self.batch_size,
-            )
+        for job in jobs:
+            self.kill(job, save=False)
+            job.updated_at = now
+            job.save()
 
         return jobs
 


### PR DESCRIPTION
This might seem more efficient, but if one submission or kill fails for whatever
reason, all the status updates and job id collection is rolled back,
leaving the jobs useless.